### PR TITLE
feat: add comment functionality to event detail page

### DIFF
--- a/culture_hub/templates/event_detail.html
+++ b/culture_hub/templates/event_detail.html
@@ -152,5 +152,70 @@
             </div>
         </div>
     </div>
+
+    <!-- Comments Section -->
+    <div class="row mt-5">
+        <div class="col-lg-8">
+            <h3 class="fw-bold mb-4">Comments</h3>
+            {% if user_is_logged_in and not user_has_commented %}
+            <div class="card mb-4">
+                <div class="card-body">
+                    <form method="post" action="{% url 'add_comment' event.id %}">
+                        {% csrf_token %}
+                        <div class="mb-3">
+                            <label for="rating" class="form-label">Rating</label>
+                            <select name="rating" id="rating" class="form-select" required>
+                                <option value="">Select rating</option>
+                                {% for i in "12345" %}
+                                <option value="{{ i }}" {% if form_data.rating|stringformat:'s' == i %}selected{% endif %}>{{ i }}</option>
+                                {% endfor %}
+                            </select>
+                            {% if errors.rating %}<div class="text-danger small">{{ errors.rating }}</div>{% endif %}
+                        </div>
+                        <div class="mb-3">
+                            <label for="comment" class="form-label">Comment</label>
+                            <textarea name="comment" id="comment" class="form-control" rows="3"
+                                required>{{ form_data.comment|default:'' }}</textarea>
+                            {% if errors.comment %}<div class="text-danger small">{{ errors.comment }}</div>{% endif %}
+                        </div>
+                        <button type="submit" class="btn btn-primary">Add Comment</button>
+                    </form>
+                </div>
+            </div>
+            {% elif user_is_logged_in and user_has_commented %}
+            <div class="alert alert-info">You have already commented on this event.</div>
+            {% else %}
+            <div class="alert alert-info">Please <a href="{% url 'login' %}">login</a> to add a comment.</div>
+            {% endif %}
+
+            {% if comments %}
+            <ul class="list-group">
+                {% for comment in comments %}
+                <li class="list-group-item py-3">
+                    <div class="d-flex justify-content-between align-items-center mb-1 flex-wrap">
+                        <div class="d-flex align-items-center gap-2 flex-wrap">
+                            <span class="fw-semibold fs-5">{{ comment.user.username }}</span>
+                            <span class="badge bg-warning text-dark ms-1">Rating: {{ comment.rating }}/5</span>
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <span class="text-muted small">{{ comment.created_at|date:"M d, Y H:i" }}</span>
+                            {% if request.session.user_role == 'admin' or comment.user_id == request.session.user_id %}
+                            <form method="post" action="{% url 'delete_comment' comment.id %}" class="d-inline"
+                                onsubmit="return confirm('Delete this comment?');">
+                                {% csrf_token %}
+                                <button type="submit" class="btn btn-sm btn-danger ms-2">Delete</button>
+                            </form>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="ps-1 mt-1 text-break" style="font-size: 1.08rem;">{{ comment.comment }}</div>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <div class="alert alert-secondary mt-3">No comments yet. Be the first to comment!</div>
+            {% endif %}
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/culture_hub/templates/event_list.html
+++ b/culture_hub/templates/event_list.html
@@ -34,7 +34,8 @@
             <select name="category" class="form-select">
                 <option value="">All Categories</option>
                 {% for category in all_categories %}
-                <option value="{{ category }}" {% if selected.category == category %}selected{% endif %}>{{ category }}</option>
+                <option value="{{ category }}" {% if selected.category == category %}selected{% endif %}>{{ category }}
+                </option>
                 {% endfor %}
             </select>
         </div>

--- a/culture_hub/urls.py
+++ b/culture_hub/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('event/<int:event_id>/', views.event_detail, name='event_detail'),
     path('event/<int:event_id>/book/', views.book_event, name='book_event'),
     path('event/<int:event_id>/delete/', views.delete_event, name='delete_event'),
+    path('event/<int:event_id>/add_comment/', views.add_comment, name='add_comment'),
 
     path('organizer/bookings/<int:event_id>/', views.organizer_manage_bookings, name='organizer_manage_bookings'),
     path('organizer/bookings/<int:booking_id>/confirm/', views.organizer_confirm_booking, name='organizer_confirm_booking'),
@@ -50,5 +51,6 @@ urlpatterns = [
     path('blogs/submit/success/', views.blog_submit_success, name='blog_submit_success'),
     path('blogs/<int:blog_id>/', views.blog_detail, name='blog_detail'),
     path('blogs/<int:blog_id>/delete/', views.delete_blog, name='delete_blog'),
+    path('comment/<int:comment_id>/delete/', views.delete_comment, name='delete_comment'),
 
 ]

--- a/culture_hub/views.py
+++ b/culture_hub/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Sum, Q
 from django.contrib import messages
 from django.utils import timezone
-from .models import User, Profile, Event, EventBooking, Payment, Blog, Category
+from .models import User, Profile, Event, EventBooking, Payment, Blog, Category, Comment
 from .forms import ProfileForm
 from django.contrib.auth.decorators import login_required as django_login_required
 
@@ -586,11 +586,52 @@ def profile_settings(request):
 
 def event_detail(request, event_id):
     event = get_object_or_404(Event, id=event_id, is_approved=True)
+    comments = Comment.objects.filter(event=event).select_related('user').order_by('-created_at')
+    user_id = request.session.get('user_id')
+    user_has_commented = False
+    if user_id:
+        user_has_commented = Comment.objects.filter(event=event, user_id=user_id).exists()
     context = {
         'event': event,
-        'user_is_logged_in': request.session.get('user_id') is not None,
+        'user_is_logged_in': user_id is not None,
+        'comments': comments,
+        'user_has_commented': user_has_commented,
     }
     return render(request, 'event_detail.html', context)
+
+@login_required
+def add_comment(request, event_id):
+    event = get_object_or_404(Event, id=event_id, is_approved=True)
+    user = User.objects.get(id=request.session['user_id'])
+    # Prevent multiple comments per user per event
+    if Comment.objects.filter(event=event, user=user).exists():
+        messages.error(request, 'You have already commented on this event.')
+        return redirect('event_detail', event_id=event.id)
+    if request.method == 'POST':
+        rating = request.POST.get('rating')
+        comment_text = request.POST.get('comment', '').strip()
+        errors = {}
+        try:
+            rating = int(rating)
+            if rating < 1 or rating > 5:
+                errors['rating'] = 'Rating must be between 1 and 5.'
+        except (TypeError, ValueError):
+            errors['rating'] = 'Rating is required.'
+        if not comment_text:
+            errors['comment'] = 'Comment cannot be empty.'
+        if errors:
+            comments = Comment.objects.filter(event=event).select_related('user').order_by('-created_at')
+            context = {
+                'event': event,
+                'user_is_logged_in': True,
+                'comments': comments,
+                'errors': errors,
+                'form_data': {'rating': rating, 'comment': comment_text},
+            }
+            return render(request, 'event_detail.html', context)
+        Comment.objects.create(event=event, user=user, rating=rating, comment=comment_text)
+        messages.success(request, 'Comment added!')
+    return redirect('event_detail', event_id=event.id)
 
 def blog_list(request):
     blogs = Blog.objects.filter(is_approved=True).order_by('-created_at')
@@ -677,3 +718,20 @@ def delete_blog(request, blog_id):
     else:
         messages.error(request, 'You do not have permission to delete this blog post.')
         return redirect('blog_list')
+
+@login_required
+def delete_comment(request, comment_id):
+    user_id = request.session.get('user_id')
+    user_role = request.session.get('user_role')
+    comment = get_object_or_404(Comment, id=comment_id)
+    event_id = comment.event.id
+    # Allow admin or comment owner
+    if user_role != 'admin' and comment.user_id != user_id:
+        messages.error(request, 'You do not have permission to delete this comment.')
+        return redirect('event_detail', event_id=event_id)
+    if request.method == 'POST':
+        comment.delete()
+        messages.success(request, 'Comment deleted.')
+    else:
+        messages.error(request, 'Invalid request method.')
+    return redirect('event_detail', event_id=event_id)


### PR DESCRIPTION
- Implemented the ability for users to add comments to events, including a rating system.
- Added a comments section in the event detail template to display existing comments.
- Users can only comment once per event, with appropriate error handling for invalid inputs.
- Admins and comment owners can delete comments, with permission checks in place.